### PR TITLE
allow customizing the reason and consumer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,23 +3,27 @@ use anyhow::Result;
 mod sys;
 
 // TODO Should this be a builder for Awake instead of public fields?
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct AwakeOptions {
     pub display: bool,
     pub idle: bool,
     pub sleep: bool,
+    /// Reason the consumer is keeping the system awake. Defaults to "User requested".
+    pub reason: Option<String>,
+    /// Reason name of the program keeping the system awake. Defaults to "keepawake-rs" if not given.
+    pub consumer: Option<String>,
 }
 
+/// Once created, keeps the machine or display awake (as requested in the
+/// AwakeOptions) until dropped.
 pub struct Awake {
     _imp: sys::Awake,
-    _options: AwakeOptions,
 }
 
 impl Awake {
-    pub fn new(options: &AwakeOptions) -> Result<Self> {
+    pub fn new(options: AwakeOptions) -> Result<Self> {
         Ok(Awake {
             _imp: sys::Awake::new(options)?,
-            _options: *options,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,27 @@ pub struct AwakeOptions {
     pub sleep: bool,
     /// Reason the consumer is keeping the system awake. Defaults to "User requested".
     pub reason: Option<String>,
-    /// Reason name of the program keeping the system awake. Defaults to "keepawake-rs" if not given.
+    /// Name of the program keeping the system awake. Defaults to "keepawake-rs" if not given.
     pub consumer: Option<String>,
+    /// Domain name of the program keeping the system awake. Defaults to "io.github.segevfiner.keepawake-rs" if not given.
+    pub consumer_domain: Option<String>,
+}
+
+impl AwakeOptions {
+    #[allow(dead_code)] // unused on Windows
+    pub(crate) fn reason(&self) -> &str {
+        self.reason.as_deref().unwrap_or("User requested")
+    }
+
+    #[allow(dead_code)] // unused on macOS and Windows
+    pub(crate) fn consumer(&self) -> &str {
+        self.reason.as_deref().unwrap_or("keepawake-rs")
+    }
+
+    #[allow(dead_code)] // unused on macOS and Windows
+    pub(crate) fn consumer_domain(&self) -> &str {
+        self.reason.as_deref().unwrap_or("io.github.segevfiner.keepawake-rs")
+    }
 }
 
 /// Once created, keeps the machine or display awake (as requested in the

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,10 +60,11 @@ fn main() -> Result<()> {
         .expect("Error setting Ctrl-C handler");
 
     let exit_code = {
-        let _awake = Awake::new(&AwakeOptions {
+        let _awake = Awake::new(AwakeOptions {
             display: cli.display,
             idle: cli.idle,
             sleep: cli.sleep,
+            ..Default::default()
         })?;
 
         if !cli.command.is_empty() {

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -51,9 +51,9 @@ pub struct Awake {
 }
 
 impl Awake {
-    pub fn new(options: &AwakeOptions) -> Result<Self> {
+    pub fn new(options: AwakeOptions) -> Result<Self> {
         let mut awake = Awake {
-            options: *options,
+            options,
 
             session_conn: None,
             screensaver_proxy: None,
@@ -75,10 +75,13 @@ impl Awake {
                 self.session_conn.as_ref().unwrap(),
             )?);
             Some(
-                self.screensaver_proxy
-                    .as_ref()
-                    .unwrap()
-                    .inhibit("io.github.segevfiner.keepawake-rs", "User requested")?,
+                self.screensaver_proxy.as_ref().unwrap().inhibit(
+                    self.options
+                        .consumer
+                        .as_deref()
+                        .unwrap_or("io.github.segevfiner.keepawake-rs"),
+                    self.options.reason.as_deref().unwrap_or("User requested"),
+                )?,
             )
         } else {
             None
@@ -94,8 +97,8 @@ impl Awake {
         self.idle_fd = if self.options.idle {
             Some(self.manager_proxy.as_ref().unwrap().inhibit(
                 "idle",
-                "keepawake-rs",
-                "User requested",
+                self.options.consumer.as_deref().unwrap_or("keepawake-rs"),
+                self.options.reason.as_deref().unwrap_or("User requested"),
                 "block",
             )?)
         } else {
@@ -105,8 +108,8 @@ impl Awake {
         self.sleep_fd = if self.options.sleep {
             Some(self.manager_proxy.as_ref().unwrap().inhibit(
                 "sleep",
-                "keepawake-rs",
-                "User requested",
+                self.options.consumer.as_deref().unwrap_or("keepawake-rs"),
+                self.options.reason.as_deref().unwrap_or("User requested"),
                 "block",
             )?)
         } else {

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -75,13 +75,10 @@ impl Awake {
                 self.session_conn.as_ref().unwrap(),
             )?);
             Some(
-                self.screensaver_proxy.as_ref().unwrap().inhibit(
-                    self.options
-                        .consumer
-                        .as_deref()
-                        .unwrap_or("io.github.segevfiner.keepawake-rs"),
-                    self.options.reason.as_deref().unwrap_or("User requested"),
-                )?,
+                self.screensaver_proxy
+                    .as_ref()
+                    .unwrap()
+                    .inhibit(self.options.consumer_domain(), self.options.reason())?,
             )
         } else {
             None
@@ -97,8 +94,8 @@ impl Awake {
         self.idle_fd = if self.options.idle {
             Some(self.manager_proxy.as_ref().unwrap().inhibit(
                 "idle",
-                self.options.consumer.as_deref().unwrap_or("keepawake-rs"),
-                self.options.reason.as_deref().unwrap_or("User requested"),
+                self.options.consumer(),
+                self.options.reason(),
                 "block",
             )?)
         } else {
@@ -108,8 +105,8 @@ impl Awake {
         self.sleep_fd = if self.options.sleep {
             Some(self.manager_proxy.as_ref().unwrap().inhibit(
                 "sleep",
-                self.options.consumer.as_deref().unwrap_or("keepawake-rs"),
-                self.options.reason.as_deref().unwrap_or("User requested"),
+                self.options.consumer(),
+                self.options.reason(),
                 "block",
             )?)
         } else {

--- a/src/sys/macos.rs
+++ b/src/sys/macos.rs
@@ -50,8 +50,7 @@ impl Awake {
                     CFString::from_static_string(kIOPMAssertionTypePreventUserIdleDisplaySleep)
                         .as_concrete_TypeRef() as CFStringRef,
                     kIOPMAssertionLevelOn,
-                    CFString::new(self.options.reason.as_deref().unwrap_or("User requested"))
-                        .as_concrete_TypeRef() as CFStringRef,
+                    CFString::new(self.options.reason()).as_concrete_TypeRef() as CFStringRef,
                     &mut self.display_assertion,
                 );
                 if result != kIOReturnSuccess as i32 {
@@ -67,8 +66,7 @@ impl Awake {
                     CFString::from_static_string(kIOPMAssertionTypePreventUserIdleSystemSleep)
                         .as_concrete_TypeRef() as CFStringRef,
                     kIOPMAssertionLevelOn,
-                    CFString::new(self.options.reason.as_deref().unwrap_or("User requested"))
-                        .as_concrete_TypeRef() as CFStringRef,
+                    CFString::new(self.options.reason()).as_concrete_TypeRef() as CFStringRef,
                     &mut self.idle_assertion,
                 );
                 if result != kIOReturnSuccess as i32 {
@@ -83,8 +81,7 @@ impl Awake {
                     CFString::from_static_string(kIOPMAssertionTypePreventSystemSleep)
                         .as_concrete_TypeRef() as CFStringRef,
                     kIOPMAssertionLevelOn,
-                    CFString::new(self.options.reason.as_deref().unwrap_or("User requested"))
-                        .as_concrete_TypeRef() as CFStringRef,
+                    CFString::new(self.options.reason()).as_concrete_TypeRef() as CFStringRef,
                     &mut self.sleep_assertion,
                 );
                 if result != kIOReturnSuccess as i32 {

--- a/src/sys/macos.rs
+++ b/src/sys/macos.rs
@@ -31,9 +31,9 @@ pub struct Awake {
 }
 
 impl Awake {
-    pub fn new(options: &AwakeOptions) -> Result<Self> {
+    pub fn new(options: AwakeOptions) -> Result<Self> {
         let mut awake = Awake {
-            options: *options,
+            options,
             display_assertion: 0,
             idle_assertion: 0,
             sleep_assertion: 0,
@@ -50,7 +50,8 @@ impl Awake {
                     CFString::from_static_string(kIOPMAssertionTypePreventUserIdleDisplaySleep)
                         .as_concrete_TypeRef() as CFStringRef,
                     kIOPMAssertionLevelOn,
-                    CFString::new("User requested").as_concrete_TypeRef() as CFStringRef,
+                    CFString::new(self.options.reason.as_deref().unwrap_or("User requested"))
+                        .as_concrete_TypeRef() as CFStringRef,
                     &mut self.display_assertion,
                 );
                 if result != kIOReturnSuccess as i32 {
@@ -66,7 +67,8 @@ impl Awake {
                     CFString::from_static_string(kIOPMAssertionTypePreventUserIdleSystemSleep)
                         .as_concrete_TypeRef() as CFStringRef,
                     kIOPMAssertionLevelOn,
-                    CFString::new("User requested").as_concrete_TypeRef() as CFStringRef,
+                    CFString::new(self.options.reason.as_deref().unwrap_or("User requested"))
+                        .as_concrete_TypeRef() as CFStringRef,
                     &mut self.idle_assertion,
                 );
                 if result != kIOReturnSuccess as i32 {
@@ -81,7 +83,8 @@ impl Awake {
                     CFString::from_static_string(kIOPMAssertionTypePreventSystemSleep)
                         .as_concrete_TypeRef() as CFStringRef,
                     kIOPMAssertionLevelOn,
-                    CFString::new("User requested").as_concrete_TypeRef() as CFStringRef,
+                    CFString::new(self.options.reason.as_deref().unwrap_or("User requested"))
+                        .as_concrete_TypeRef() as CFStringRef,
                     &mut self.sleep_assertion,
                 );
                 if result != kIOReturnSuccess as i32 {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -22,9 +22,9 @@ pub struct Awake {
 }
 
 impl Awake {
-    pub fn new(options: &AwakeOptions) -> Result<Self> {
+    pub fn new(options: AwakeOptions) -> Result<Self> {
         let mut awake = Awake {
-            options: *options,
+            options,
             previous: Default::default(),
         };
         awake.set()?;


### PR DESCRIPTION
I think a builder might be nicer for the AwakeOptions, but I started with the simpler change for now 🙂  Unfortunately, since it isn't a builder and not `#[not_exhaustive]`, adding any new struct fields is technically breaking.

I also dropped the `Copy` trait, since strings are not copyable. But I think that's fine -- if Awake takes AwakeOptions instead of a reference to them, and doesn't store a duplicate `_options`, then there's no need to clone or copy them.

Fixes https://github.com/segevfiner/keepawake-rs/issues/4