### PR TITLE
Get rid off dbus_proxy warning about defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,9 +2000,9 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zbus"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a0b85c5608c27d2306d67e955b9c6e23a42d824205c85038a7afbe19c0ae22"
+checksum = "a25ae891bd547674b368906552115143031c16c23a0f2f4b2f5f5436ab2e6a9f"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18018648e7e10ed856809befe7309002b87b2b12d5b282cb5040d7974b58677"
+checksum = "8aa37701ce7b3a43632d2b0ad9d4aef602b46be6bdd7fba3b7c5007f9f6eb2c2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794fb7f59af4105697b0449ba31731ee5dbb3e773a17dbdf3d36206ea1b1644"
+checksum = "5c817f416f05fcbc833902f1e6064b72b1778573978cfeac54731451ccc9e207"
 dependencies = [
  "byteorder",
  "enumflags2",
@@ -2077,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd58d4b6c8e26d3dd2149c8c40c6613ef6451b9885ff1296d1ac86c388351a54"
+checksum = "fdd24fffd02794a76eb10109de463444064c88f5adb9e9d1a78488adc332bfef"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-zbus = "3.1.0"
+zbus = "3.5.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-sys = { version = "0.1.2", features = ["CoreFoundation", "IOKit"] }

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -28,7 +28,7 @@ trait Manager {
     ) -> zbus::Result<zbus::zvariant::OwnedFd>;
 }
 
-#[dbus_proxy]
+#[dbus_proxy(assume_defaults = true)]
 trait ScreenSaver {
     /// Inhibit method
     fn inhibit(&self, application_name: &str, reason_for_inhibit: &str) -> zbus::Result<u32>;


### PR DESCRIPTION
`zbus` [introduced](https://gitlab.freedesktop.org/dbus/zbus/-/commit/5db2d13fa80fd68f8f7c9178259cd5a18a3e00ea) `assume_defaults` attribute for `dbus_proxy` macro in version 3.5.0. They also started to print a warning if neither of `assume_defaults`/`default_path`/`default_service` were specified, which for keepawake looked like this:

```
#[dbus_proxy(...)] macro invocation on 'ScreenSaverProxyBlocking' without explicit defaults. Please set 'assume_defaults = true', or configure default path/service directly.
#[dbus_proxy(...)] macro invocation on 'ScreenSaverProxy' without explicit defaults. Please set 'assume_defaults = true', or configure default path/service directly.
```

This PR updates the zbus dependency to 3.5.0 and sets `assume_defaults = true` which is, according to [docs](https://docs.rs/zbus/latest/zbus/attr.dbus_proxy.html), the current default. Hence the warning is gone.