### PR TITLE
Make shadow-rs build dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,5 @@ apple-sys = { version = "0.2.0", features = ["CoreFoundation", "IOKit"] }
 core-foundation = "0.9.3"
 
 [build-dependencies]
-shadow-rs = "0.24.0"
+shadow-rs = { version = "0.24.0", optional = true }
 winresource = "0.1.17"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::env;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(feature = "bin")]
     shadow_rs::new()?;
 
     if env::var("CARGO_FEATURE_BIN").is_ok() && env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {


### PR DESCRIPTION
When depending on this as a library, `shadow-rs` gets pulled in as a build dependency. This PR makes it so that it's only added as a build dependency when the `bin` feature is specified.

Tested by making a small bin crate with just `keepawake` as a dependency, and checked that the `Cargo.lock` didn't contain `shadow-rs`.